### PR TITLE
Pull request for WAZO-892-headers-exchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+*.coverage
+*.egg-info
+*.pyc
 *.swp
-*.egg-info/
-__pycache__
+*.tox
+coverage.xml
+nosetests.xml
+pycodestyle.txt
+pylint.txt

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 wazo-websocketd is a WebSocket server that delivers Wazo related events to clients.
 
-Contrary to most other Wazo components, this is a python 3 only project. Both
-the code, the unit tests and the integration tests must be run with python 3.
-
 ## Dependencies
 
 * python >= 3.4

--- a/etc/wazo-websocketd/config.yml
+++ b/etc/wazo-websocketd/config.yml
@@ -46,8 +46,8 @@
 #  port: 5672
 #  username: guest
 #  password: guest
-#  exchange_name: xivo
-#  exchange_type: topic
+#  exchange_name: wazo-headers
+#  exchange_type: headers
 
 ## Developer options -- do not use them
 #auth_check_strategy: static

--- a/integration_tests/assets/etc/wazo-websocketd/conf.d/50-base.yml
+++ b/integration_tests/assets/etc/wazo-websocketd/conf.d/50-base.yml
@@ -1,3 +1,4 @@
+debug: true
 websocket:
   certificate: /usr/local/share/ssl/websocketd/server.crt
   private_key: /usr/local/share/ssl/websocketd/server.key

--- a/integration_tests/suite/helpers/auth.py
+++ b/integration_tests/suite/helpers/auth.py
@@ -19,14 +19,11 @@ class AuthServer(object):
         disable_warnings()
 
     @asyncio.coroutine
-    def put_token(self, token_id, auth_id='123-456', acls=['websocketd']):
+    def put_token(self, token_id, user_uuid='123-456', acls=['websocketd']):
         token = {
             'token': token_id,
-            'auth_id': auth_id,
             'acls': acls,
-            'metadata': {
-                'uuid': xivo_user_uuid,
-            },
+            'metadata': {'uuid': user_uuid},
         }
         return (yield from self._loop.run_in_executor(None, self._sync_put_token, token))
 

--- a/integration_tests/suite/helpers/auth.py
+++ b/integration_tests/suite/helpers/auth.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import asyncio
@@ -19,11 +19,10 @@ class AuthServer(object):
         disable_warnings()
 
     @asyncio.coroutine
-    def put_token(self, token_id, auth_id='123-456', xivo_user_uuid=None, acls=['websocketd']):
+    def put_token(self, token_id, auth_id='123-456', acls=['websocketd']):
         token = {
             'token': token_id,
             'auth_id': auth_id,
-            'xivo_user_uuid': xivo_user_uuid,
             'acls': acls,
             'metadata': {
                 'uuid': xivo_user_uuid,

--- a/wazo_websocketd/acl.py
+++ b/wazo_websocketd/acl.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
@@ -16,8 +16,8 @@ import re
 
 class ACLCheck(object):
 
-    def __init__(self, auth_id, acls):
-        self._auth_id = auth_id
+    def __init__(self, user_uuid, acls):
+        self._user_uuid = user_uuid
         self._acls = acls
 
     def matches_required_acl(self, required_acl):
@@ -26,9 +26,9 @@ class ACLCheck(object):
 
         for user_acl in self._acls:
             if user_acl.endswith('.me'):
-                user_acl = '{}.{}'.format(user_acl[:-3], self._auth_id)
+                user_acl = '{}.{}'.format(user_acl[:-3], self._user_uuid)
             else:
-                user_acl = user_acl.replace('.me.', '.{}.'.format(self._auth_id))
+                user_acl = user_acl.replace('.me.', '.{}.'.format(self._user_uuid))
 
             user_acl_regex = self._transform_acl_to_regex(user_acl)
             if re.match(user_acl_regex, required_acl):

--- a/wazo_websocketd/bus.py
+++ b/wazo_websocketd/bus.py
@@ -133,7 +133,7 @@ class _BusEventService(object):
                 # (user or admin). An empty routing-key with headers exchange mean all events
                 yield from self._bus_connection.add_queue_binding('')
 
-        acl_check = ACLCheck(token['auth_id'], token['acls'])
+        acl_check = ACLCheck(token['metadata']['uuid'], token['acls'])
         bus_event_consumer = _BusEventConsumer(self._loop, self._bus_event_dispatcher, acl_check)
         self._bus_event_dispatcher.add_event_consumer(bus_event_consumer)
         return bus_event_consumer

--- a/wazo_websocketd/config.py
+++ b/wazo_websocketd/config.py
@@ -29,8 +29,8 @@ _DEFAULT_CONFIG = {
         'port': 5672,
         'username': 'guest',
         'password': 'guest',
-        'exchange_name': 'xivo',
-        'exchange_type': 'topic',
+        'exchange_name': 'wazo-headers',
+        'exchange_type': 'headers',
     },
     'websocket': {
         'listen': '0.0.0.0',

--- a/wazo_websocketd/tests/test_acl.py
+++ b/wazo_websocketd/tests/test_acl.py
@@ -10,11 +10,11 @@ from ..acl import ACLCheck
 class TestACLCheck(unittest.TestCase):
 
     def setUp(self):
-        self.auth_id = '123'
+        self.user_uuid = '123'
 
     def test_matches_required_acls_when_user_acl_ends_with_hashtag(self):
         acls = ['foo.bar.#']
-        acl_check = ACLCheck(self.auth_id, acls)
+        acl_check = ACLCheck(self.user_uuid, acls)
 
         assert_that(acl_check.matches_required_acl('foo.bar'), equal_to(False))
         assert_that(acl_check.matches_required_acl('foo.bar.toto'))
@@ -23,7 +23,7 @@ class TestACLCheck(unittest.TestCase):
 
     def test_matches_required_acls_when_user_acl_has_not_special_character(self):
         acls = ['foo.bar.toto']
-        acl_check = ACLCheck(self.auth_id, acls)
+        acl_check = ACLCheck(self.user_uuid, acls)
 
         assert_that(acl_check.matches_required_acl('foo.bar.toto'))
         assert_that(acl_check.matches_required_acl('foo.bar.toto.tata'), equal_to(False))
@@ -31,7 +31,7 @@ class TestACLCheck(unittest.TestCase):
 
     def test_matches_required_acls_when_user_acl_has_asterisks(self):
         acls = ['foo.*.*']
-        acl_check = ACLCheck(self.auth_id, acls)
+        acl_check = ACLCheck(self.user_uuid, acls)
 
         assert_that(acl_check.matches_required_acl('foo.bar.toto'))
         assert_that(acl_check.matches_required_acl('foo.bar.toto.tata'), equal_to(False))
@@ -39,7 +39,7 @@ class TestACLCheck(unittest.TestCase):
 
     def test_matches_required_acls_with_multiple_acls(self):
         acls = ['foo', 'foo.bar.toto', 'other.#']
-        acl_check = ACLCheck(self.auth_id, acls)
+        acl_check = ACLCheck(self.user_uuid, acls)
 
         assert_that(acl_check.matches_required_acl('foo'))
         assert_that(acl_check.matches_required_acl('foo.bar'), equal_to(False))
@@ -49,7 +49,7 @@ class TestACLCheck(unittest.TestCase):
 
     def test_matches_required_acls_when_user_acl_has_hashtag_in_middle(self):
         acls = ['foo.bar.#.titi']
-        acl_check = ACLCheck(self.auth_id, acls)
+        acl_check = ACLCheck(self.user_uuid, acls)
 
         assert_that(acl_check.matches_required_acl('foo.bar'), equal_to(False))
         assert_that(acl_check.matches_required_acl('foo.bar.toto'), equal_to(False))
@@ -58,7 +58,7 @@ class TestACLCheck(unittest.TestCase):
 
     def test_matches_required_acls_when_user_acl_ends_with_me(self):
         acls = ['foo.#.me']
-        acl_check = ACLCheck(self.auth_id, acls)
+        acl_check = ACLCheck(self.user_uuid, acls)
 
         assert_that(acl_check.matches_required_acl('foo.bar'), equal_to(False))
         assert_that(acl_check.matches_required_acl('foo.bar.123'))
@@ -67,7 +67,7 @@ class TestACLCheck(unittest.TestCase):
 
     def test_matches_required_acls_when_user_acl_has_me_in_middle(self):
         acls = ['foo.#.me.bar']
-        acl_check = ACLCheck(self.auth_id, acls)
+        acl_check = ACLCheck(self.user_uuid, acls)
 
         assert_that(acl_check.matches_required_acl('foo.bar.me.bar'), equal_to(False))
         assert_that(acl_check.matches_required_acl('foo.bar.123'), equal_to(False))


### PR DESCRIPTION
remove unnecessary python3 warning
test: activate debug
do not use deprecated token auth_id field
remove unused and deprecated xivo_user_uuid field
add files to gitignore
bind on wazo-headers exchange instead of xivo