### PR TITLE
WAZO-1456 bus: fix the upstream exchange name and type

### DIFF
--- a/etc/wazo-websocketd/config.yml
+++ b/etc/wazo-websocketd/config.yml
@@ -48,6 +48,8 @@
 #  password: guest
 #  exchange_name: wazo-websocketd
 #  exchange_type: headers
+#  upstream_exchange_name: xivo
+#  upstream_exchange_type: topic
 
 ## Developer options -- do not use them
 #auth_check_strategy: static

--- a/wazo_websocketd/bus.py
+++ b/wazo_websocketd/bus.py
@@ -30,7 +30,7 @@ ROUTING_KEYS = [
     'status.#',
     'switchboards.#',
     'sysconfd.#',
-    'trunks.#'
+    'trunks.#',
     'voicemails.#',
 ]
 

--- a/wazo_websocketd/bus.py
+++ b/wazo_websocketd/bus.py
@@ -57,7 +57,13 @@ def create_or_update_exchange(config):
         upstream_exchange.bind(connection).declare()
         exchange = exchange.bind(connection)
         exchange.declare()
+        # This unbind_from and the one in the loop were added in 20.01 because we created
+        # a bind on the wrong exchange (wazo-headers) in a previous version
+        exchange.unbind_from('wazo-headers', 'trunks.#voicemails.#')  # Migrate <20.01
         for routing_key in ROUTING_KEYS:
+            exchange.unbind_from(
+                'wazo-headers', routing_key=routing_key
+            )  # Migrate <20.01
             exchange.bind_to(upstream_exchange, routing_key=routing_key)
 
 

--- a/wazo_websocketd/bus.py
+++ b/wazo_websocketd/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import asyncio
@@ -40,7 +40,7 @@ def create_or_update_exchange(config):
 
     upstream_exchange = kombu.Exchange(
         config['bus']['upstream_exchange_name'],
-        type=config['bus']['exchange_type'],
+        type=config['bus']['upstream_exchange_type'],
         auto_delete=False,
         durable=True,
         delivery_mode='persistent',

--- a/wazo_websocketd/config.py
+++ b/wazo_websocketd/config.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -31,7 +31,8 @@ _DEFAULT_CONFIG = {
         'password': 'guest',
         'exchange_name': 'wazo-websocketd',
         'exchange_type': 'headers',
-        'upstream_exchange_name': 'wazo-headers',
+        'upstream_exchange_name': 'xivo',
+        'upstream_exchange_type': 'topic',
     },
     'websocket': {
         'listen': '0.0.0.0',


### PR DESCRIPTION
the wazo-websocketd exchange should be populated from the xivo exchange based on
the routing keys listed in bus.py.

binding on the wazo-headers does not work since it does not use routing keys