### PR TITLE
fix: validate the correct token

### DIFF
--- a/integration_tests/suite/test_authentication.py
+++ b/integration_tests/suite/test_authentication.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import websockets
@@ -76,6 +76,7 @@ class TestTokenExpiration(IntegrationTest):
         await self.websocketd_client.op_start()
         self.auth_server.put_token("new-token")
         await self.websocketd_client.op_token("new-token")
+        self.auth_server.remove_token(self.token_id)
         self.websocketd_client.timeout = self._TIMEOUT
         await self.websocketd_client.wait_for_nothing()
 

--- a/wazo_websocketd/auth.py
+++ b/wazo_websocketd/auth.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import asyncio
@@ -48,9 +48,9 @@ class _StaticIntervalAuthCheck(object):
 
     async def run(self, token_getter):
         while True:
-            token_id = token_getter()['token']
             await asyncio.sleep(self._interval)
             logger.debug('static auth check: testing token validity')
+            token_id = token_getter()['token']
             is_valid = await self._async_auth_client.is_valid_token(token_id)
             if not is_valid:
                 raise AuthenticationExpiredError()


### PR DESCRIPTION
The period task was a bit bugged it was retrieving the token from the
websocket session, wait one minute, then validate the token.

So if new token is sent by the client to the websocket session, we end
up to not validate the correct one.

This ensure we always validate the latest one.
