### PR TITLE
test: use explicit ipv4 addr to connect docker

### DIFF
--- a/integration_tests/suite/helpers/auth.py
+++ b/integration_tests/suite/helpers/auth.py
@@ -8,7 +8,7 @@ from xivo_test_helpers.auth import AuthClient, MockUserToken
 class AuthServer(object):
     def __init__(self, loop, port):
         self._loop = loop
-        self._client = AuthClient('localhost', port)
+        self._client = AuthClient('127.0.0.1', port)
         disable_warnings()
 
     def put_token(

--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -15,7 +15,7 @@ class BusClient(object):
 
     async def connect(self):
         self._connection = await asynqp.connect(
-            'localhost', loop=self._loop, port=self._port
+            '127.0.0.1', loop=self._loop, port=self._port
         )
         self._channel = await self._connection.open_channel()
         self._exchange = await self._channel.declare_exchange(

--- a/integration_tests/suite/helpers/websocketd.py
+++ b/integration_tests/suite/helpers/websocketd.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import asyncio
@@ -31,7 +31,7 @@ class WebSocketdClient(object):
 
     async def connect(self, token_id, version=1):
         self._version = version
-        url = 'ws://localhost:{port}/?'.format(port=self._port)
+        url = 'ws://127.0.0.1:{port}/?'.format(port=self._port)
         if token_id is not None:
             url += 'token={}&'.format(token_id)
         if version > 1:


### PR DESCRIPTION
reason: service_port() returns only port bound to ipv4. Some host can
resolve localhost to ipv6 address and docker doesn't necessarily bind
the same port number on ipv4 and ipv6