### PR TITLE
use docker-compose from binary instead of python

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,6 +1,5 @@
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
 asynqp
-docker-compose
 pytest
 requests
 websockets


### PR DESCRIPTION
why: to have the latest docker-compose