### PR TITLE
Fix rabbitMQ restart test timeout

### DIFF
--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -1,17 +1,16 @@
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import os
 import json
 import aioamqp
 import asyncio
 from aioamqp.exceptions import AmqpClosedConnection
 
-from .constants import TENANT1_UUID, USER1_UUID
+from .constants import TENANT1_UUID, USER1_UUID, START_TIMEOUT
 
 
 class BusClient:
-    timeout = int(os.environ.get('INTEGRATION_TEST_TIMEOUT', '60'))
+    timeout = START_TIMEOUT
 
     def __init__(self, port):
         self._port = port

--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -11,7 +11,7 @@ from .constants import TENANT1_UUID, USER1_UUID
 
 
 class BusClient:
-    timeout = int(os.environ.get('INTEGRATION_TEST_TIMEOUT', '30'))
+    timeout = int(os.environ.get('INTEGRATION_TEST_TIMEOUT', '60'))
 
     def __init__(self, port):
         self._port = port

--- a/integration_tests/suite/helpers/constants.py
+++ b/integration_tests/suite/helpers/constants.py
@@ -1,11 +1,14 @@
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from os import path, environ
 import os.path
 
 from uuid import UUID
 
-ASSET_ROOT = os.path.join(os.path.dirname(__file__), '..', '..', 'assets')
+ASSET_ROOT = path.join(os.path.dirname(__file__), '..', '..', 'assets')
+
+START_TIMEOUT = int(environ.get('INTEGRATION_TEST_TIMEOUT', '60'))
 
 INVALID_TOKEN_ID = 'invalid-token'
 UNAUTHORIZED_TOKEN_ID = 'invalid-acl-token'

--- a/integration_tests/suite/helpers/wait_strategy.py
+++ b/integration_tests/suite/helpers/wait_strategy.py
@@ -20,7 +20,7 @@ class TimeWaitStrategy(WaitStrategy):
 
 
 class WaitUntilValidConnection(WaitStrategy):
-    timeout = int(os.environ.get('INTEGRATION_TEST_TIMEOUT', '30'))
+    timeout = int(os.environ.get('INTEGRATION_TEST_TIMEOUT', '60'))
 
     def wait(self, test):
         loop = asyncio.get_event_loop()

--- a/integration_tests/suite/helpers/wait_strategy.py
+++ b/integration_tests/suite/helpers/wait_strategy.py
@@ -1,11 +1,12 @@
 # Copyright 2022-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import os
 import time
 import asyncio
 
 from websockets import ConnectionClosed
+
+from .constants import START_TIMEOUT
 from .websocketd import WebSocketdClient, WebSocketdTimeoutError
 
 
@@ -20,7 +21,7 @@ class TimeWaitStrategy(WaitStrategy):
 
 
 class WaitUntilValidConnection(WaitStrategy):
-    timeout = int(os.environ.get('INTEGRATION_TEST_TIMEOUT', '60'))
+    timeout = START_TIMEOUT
 
     def wait(self, test):
         loop = asyncio.get_event_loop()

--- a/integration_tests/suite/helpers/websocketd.py
+++ b/integration_tests/suite/helpers/websocketd.py
@@ -47,6 +47,20 @@ class WebSocketdClient:
         await self.connect(token_id, version)
         await self.wait_for_close(code)
 
+    # FIXME: until proper /status route is available, this method attempts to connect
+    # until we hit timeout
+    async def retry_connect_and_wait_for_init(self, token_id, version=1, timeout=60):
+        for _ in range(timeout):
+            try:
+                await self.connect_and_wait_for_init(token_id, version)
+            except websockets.ConnectionClosed:
+                await asyncio.sleep(1)
+            else:
+                return
+        raise WebSocketdTimeoutError(
+            'failed to connect within {} seconds'.format(timeout)
+        )
+
     async def wait_for_close(self, code=None):
         # close code are defined in the "constants" module
         try:

--- a/integration_tests/suite/helpers/websocketd.py
+++ b/integration_tests/suite/helpers/websocketd.py
@@ -7,6 +7,8 @@ import uuid
 
 import websockets
 
+from .constants import START_TIMEOUT
+
 
 class WebSocketdTimeoutError(Exception):
     pass
@@ -49,7 +51,9 @@ class WebSocketdClient:
 
     # FIXME: until proper /status route is available, this method attempts to connect
     # until we hit timeout
-    async def retry_connect_and_wait_for_init(self, token_id, version=1, timeout=60):
+    async def retry_connect_and_wait_for_init(
+        self, token_id, version=1, timeout=START_TIMEOUT
+    ):
         for _ in range(timeout):
             try:
                 await self.connect_and_wait_for_init(token_id, version)

--- a/integration_tests/suite/test_bus.py
+++ b/integration_tests/suite/test_bus.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import asyncio
-import os
 
 from contextlib import asynccontextmanager
 from uuid import uuid4
@@ -254,7 +253,6 @@ class TestBusConnectionLost(IntegrationTest):
 class TestRabbitMQRestart(IntegrationTest):
 
     asset = 'basic'
-    timeout = int(os.environ.get('INTEGRATION_TEST_TIMEOUT', '60'))
 
     @run_with_loop
     async def test_can_connect_after_rabbitmq_restart(self):
@@ -268,9 +266,7 @@ class TestRabbitMQRestart(IntegrationTest):
             await self.websocketd_client.close()
             self.bus_client = self.make_bus()
             await self.bus_client.connect()
-            await self.websocketd_client.retry_connect_and_wait_for_init(
-                token, timeout=self.timeout
-            )
+            await self.websocketd_client.retry_connect_and_wait_for_init(token)
             await self.websocketd_client.op_subscribe('foo')
             await self.websocketd_client.op_start()
             await self.bus_client.publish(event)


### PR DESCRIPTION
Fixes flakyness of restarting RabbitMQ test

1. Modify timeout to 60 seconds instead of 30.  In case of slow startup (which is not uncommon) we might need at least 31 seconds to reconnect

2. Connections for the bus are pooled, with the previous method, we retried a connection until we could connect, then create a new connection to start the tests, but this can fail if not all bus connection reconnects at the same time.  This fix instead reuses the client's connection to try to reconnect until it works or timeout
