### PR TITLE
WAZO-3211: handle logging in a multiprocess environment

### DIFF
--- a/wazo_websocketd/bus.py
+++ b/wazo_websocketd/bus.py
@@ -17,7 +17,7 @@ from secrets import token_hex
 from typing import Dict, List, NamedTuple, Optional
 from xivo.auth_verifier import AccessCheck
 
-from .auth import get_master_tenant
+from .auth import MasterTenantProxy
 from .exception import (
     BusConnectionError,
     BusConnectionLostError,
@@ -47,7 +47,7 @@ class _UserHelper:
         )
 
     def is_master_tenant(self) -> bool:
-        return self.tenant_uuid == get_master_tenant()
+        return self.tenant_uuid == MasterTenantProxy.get_master_tenant()
 
     @classmethod
     def from_token(cls, token: Dict):

--- a/wazo_websocketd/controller.py
+++ b/wazo_websocketd/controller.py
@@ -7,7 +7,7 @@ import logging
 from asyncio import FIRST_COMPLETED, Future
 from signal import SIGINT, SIGTERM
 
-from .auth import ServiceTokenRenewer, set_master_tenant
+from .auth import MasterTenantProxy, ServiceTokenRenewer
 from .bus import BusService
 from .process import ProcessPool
 
@@ -35,7 +35,9 @@ class Controller:
 
         if not tombstone.done():
             async with ServiceTokenRenewer(self._config) as token_renewer:
-                token_renewer.subscribe(set_master_tenant, details=True, oneshot=True)
+                token_renewer.subscribe(
+                    MasterTenantProxy.set_master_tenant, details=True, oneshot=True
+                )
 
                 async with ProcessPool(self._config):
                     await tombstone  # wait for SIGTERM or SIGINT`

--- a/wazo_websocketd/process.py
+++ b/wazo_websocketd/process.py
@@ -5,10 +5,13 @@ import asyncio
 import logging
 import websockets
 
-from multiprocessing import Process
+from logging.handlers import QueueHandler, QueueListener
+from multiprocessing import JoinableQueue, Process
+from multiprocessing.sharedctypes import Synchronized
 from os import getpid, sched_getaffinity
 from signal import SIGINT, SIGTERM
 from typing import Dict, List, Union
+from xivo.xivo_logging import silence_loggers
 
 from .auth import Authenticator
 from .bus import BusService
@@ -58,10 +61,20 @@ class WebsocketServer:
 
 
 class ProcessWorker(Process):
-    def __init__(self, config: Dict):
-        super().__init__(target=self._run_server, args=(config,))
+    def __init__(self, config: Dict, *sync_vars):
+        super().__init__(target=self._run_server, args=(config, *sync_vars))
 
-    def _run_server(self, config):
+    def _setup_logging(self, config: Dict, log_queue: JoinableQueue):
+        handler = QueueHandler(log_queue)
+        process_logger = logging.getLogger()
+        process_logger.handlers.clear()  # clear default handlers (file, stderr, etc)
+        process_logger.addHandler(handler)  # send log messages to a queue
+        process_logger.setLevel(
+            logging.DEBUG if config.get('debug') else config['log_level']
+        )
+        silence_loggers(['aioamqp', 'urllib3'], logging.WARNING)
+
+    def _run_server(self, config: Dict, log_queue: JoinableQueue):
         async def serve(config):
             loop = asyncio.get_event_loop()
             server = WebsocketServer(config)
@@ -69,11 +82,13 @@ class ProcessWorker(Process):
             loop.add_signal_handler(SIGTERM, server.stop)
             await server.serve()
 
+        self._setup_logging(config, log_queue)
         asyncio.run(serve(config))
 
 
 class ProcessPool:
     def __init__(self, config: Dict):
+        handlers = logging.getLogger().handlers
         workers: Union[int, str] = config['process_workers']
         if workers == 'auto':
             workers = len(sched_getaffinity(0))
@@ -85,14 +100,17 @@ class ProcessPool:
 
         self._config: Dict = config
         self._poolsize: int = workers
+        self._log_queue = JoinableQueue()
+        self._log_listener = QueueListener(self._log_queue, *handlers)
         self._workers: List[ProcessWorker] = []
 
     def __len__(self):
         return len(self._workers)
 
     async def __aenter__(self):
-        self._workers = {ProcessWorker(self._config) for _ in range(self._poolsize)}
+        self._workers = {ProcessWorker(self._config, self._log_queue) for _ in range(self._poolsize)}
         logger.info('starting %d worker process(es)', self._poolsize)
+        self._log_listener.start()
         for worker in self._workers:
             worker.start()
         return self
@@ -100,3 +118,7 @@ class ProcessPool:
     async def __aexit__(self, *args):
         for worker in self._workers:
             worker.join()
+            worker.close()
+        logger.info('processing queued log messages...')
+        self._log_queue.join()
+        self._log_listener.stop()

--- a/wazo_websocketd/session.py
+++ b/wazo_websocketd/session.py
@@ -8,7 +8,7 @@ import websockets
 from typing import Optional
 from urllib.parse import urlparse, parse_qsl
 
-from .auth import has_master_tenant
+from .auth import MasterTenantProxy
 from .bus import BusConsumer, BusService
 from .exception import (
     AuthenticationError,
@@ -120,7 +120,7 @@ class Session:
             await self._ws.close(1011)
 
     async def _run(self):
-        if not has_master_tenant():
+        if not MasterTenantProxy.has_master_tenant():
             raise AuthenticationError('unable to determine master tenant')
 
         self._protocol_version = _extract_version_from_path(self._path)


### PR DESCRIPTION
Why
-----
Logging module in python is not process-safe.  In some cases, we can see worker processes get errors if they try to log while another is currently writing to the log file.  

How
-----
This commit changes the default handler for worker processes to send messages to a queue, which will then be processed in the main process, only allowing a single process to write to logfile / streams
