### PR TITLE
WAZO-3234: Fix worker process logging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Depends:
  ${misc:Depends},
  adduser,
  python3-aioamqp,
+ python3-setproctitle,
  python3-websockets,
  python3-yaml,
  python3-uvloop,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ https://github.com/wazo-platform/wazo-auth-client/archive/master.zip
 pyyaml==5.3.1
 requests==2.25.1
 stevedore==3.2.2
+setproctitle==1.2.1
 websockets==8.1
 aioamqp==0.14.0
 uvloop==0.15.0  # To simplify wheel installation, bullseye has 0.14.0

--- a/wazo_websocketd/bus.py
+++ b/wazo_websocketd/bus.py
@@ -366,11 +366,11 @@ class BusConsumer:
         self._consumer_tag = await self._consume_queue(channel, self._amqp_queue)
 
         if self._user.is_master_tenant():
-            logger.debug('user `%s` now consuming all events', self._user.uuid)
+            logger.debug('user `%s` connected as global admin', self._user.uuid)
         elif self._user.is_admin():
-            logger.debug('user `%s` now consuming tenant\'s events', self._user.uuid)
+            logger.debug('user `%s` connected as tenant\'s admin', self._user.uuid)
         else:
-            logger.debug('user `%s` now consuming user\'s events', self._user.uuid)
+            logger.debug('user `%s` connected as user', self._user.uuid)
 
     async def _stop_consuming(self) -> None:
         if self._channel.is_open:

--- a/wazo_websocketd/bus.py
+++ b/wazo_websocketd/bus.py
@@ -348,7 +348,6 @@ class BusConsumer:
             logger.debug('discarding event (reason: %s)', exc)
         else:
             self._queue.put_nowait(event)
-            logger.debug('dispatching %s', event)
         finally:
             await channel.basic_client_ack(envelope.delivery_tag, multiple=True)
 

--- a/wazo_websocketd/process.py
+++ b/wazo_websocketd/process.py
@@ -10,6 +10,7 @@ from logging.handlers import QueueHandler, QueueListener
 from multiprocessing import JoinableQueue, Process
 from multiprocessing.sharedctypes import Synchronized
 from os import getpid, sched_getaffinity
+from setproctitle import setproctitle
 from signal import SIGINT, SIGTERM
 from xivo.xivo_logging import silence_loggers
 
@@ -87,6 +88,7 @@ class ProcessWorker(Process):
             loop.add_signal_handler(SIGTERM, server.stop)
             await server.serve()
 
+        setproctitle('wazo-websocketd: worker process')
         self._setup_logging(config, log_queue)
         self._setup_master_tenant(master_tenant_proxy)
 

--- a/wazo_websocketd/process.py
+++ b/wazo_websocketd/process.py
@@ -7,11 +7,13 @@ import logging
 import websockets
 
 from logging.handlers import QueueHandler, QueueListener
-from multiprocessing import JoinableQueue, Process
+from multiprocessing import Queue, get_context
+from multiprocessing.context import SpawnProcess as Process, BaseContext
 from multiprocessing.sharedctypes import Synchronized
 from os import getpid, sched_getaffinity
 from setproctitle import setproctitle
 from signal import SIGINT, SIGTERM
+from websockets.server import Serve
 from xivo.xivo_logging import silence_loggers
 
 from .auth import Authenticator, MasterTenantProxy
@@ -24,12 +26,12 @@ logger = logging.getLogger(__name__)
 
 
 class WebsocketServer:
-    def __init__(self, config):
+    def __init__(self, config: dict):
         self._config = config
         self._tombstone = asyncio.Future()
 
-    def _create_server(self):
-        config: dict = self._config
+    def _create_server(self) -> tuple[BusService, Serve]:
+        config = self._config
         authenticator: Authenticator = Authenticator(config)
         service: BusService = BusService(config)
         factory: SessionFactory = SessionFactory(
@@ -61,33 +63,21 @@ class WebsocketServer:
         self._tombstone.set_result(True)
 
 
-class ProcessWorker(Process):
-    def __init__(self, config: dict, *sync_vars):
-        super().__init__(target=self._run_server, args=(config, *sync_vars))
-
-    def _setup_master_tenant(self, proxy: Synchronized):
-        MasterTenantProxy.proxy = proxy
-
-    def _setup_logging(self, config: dict, log_queue: JoinableQueue):
-        handler = QueueHandler(log_queue)
-        process_logger = logging.getLogger()
-        process_logger.handlers.clear()  # clear default handlers (file, stderr, etc)
-        process_logger.addHandler(handler)  # send log messages to a queue
-        process_logger.setLevel(
-            logging.DEBUG if config.get('debug') else config['log_level']
+class ProcessWorker:
+    def __init__(self, context: BaseContext, config: dict, *sync_vars):
+        self._process: Process = context.Process(
+            target=self._run_server, args=(config, *sync_vars)
         )
-        silence_loggers(['aioamqp', 'urllib3'], logging.WARNING)
+
+    def join(self):
+        self._process.join()
+
+    def start(self):
+        self._process.start()
 
     def _run_server(
-        self, config: dict, log_queue: JoinableQueue, master_tenant_proxy: Synchronized
+        self, config: dict, log_queue: Queue, master_tenant_proxy: Synchronized
     ):
-        async def serve(config):
-            loop = asyncio.get_event_loop()
-            server = WebsocketServer(config)
-            loop.add_signal_handler(SIGINT, server.stop)
-            loop.add_signal_handler(SIGTERM, server.stop)
-            await server.serve()
-
         setproctitle('wazo-websocketd: worker process')
         self._setup_logging(config, log_queue)
         self._setup_master_tenant(master_tenant_proxy)
@@ -97,15 +87,35 @@ class ProcessWorker(Process):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         try:
-            loop.run_until_complete(serve(config))
+            loop.run_until_complete(self._serve(config))
         finally:
             loop.run_until_complete(loop.shutdown_asyncgens())
             loop.close()
 
+    @staticmethod
+    async def _serve(config: dict):
+        loop = asyncio.get_event_loop()
+        server = WebsocketServer(config)
+        loop.add_signal_handler(SIGINT, server.stop)
+        loop.add_signal_handler(SIGTERM, server.stop)
+        await server.serve()
+
+    def _setup_master_tenant(self, proxy: Synchronized):
+        MasterTenantProxy.proxy = proxy
+
+    def _setup_logging(self, config: dict, log_queue: Queue):
+        handler = QueueHandler(log_queue)
+        process_logger = logging.getLogger()
+        process_logger.handlers.clear()  # clear default handlers (file, stderr, etc)
+        process_logger.addHandler(handler)  # send log messages to a queue
+        process_logger.setLevel(
+            logging.DEBUG if config.get('debug') else config['log_level']
+        )
+        silence_loggers(['aioamqp', 'urllib3'], logging.WARNING)
+
 
 class ProcessPool:
     def __init__(self, config: dict):
-        handlers = logging.getLogger().handlers
         workers: int | str = config['process_workers']
         if workers == 'auto':
             workers = len(sched_getaffinity(0))
@@ -115,21 +125,20 @@ class ProcessPool:
                 'configuration key `process_workers` must be a positive integer or `auto`'
             )
 
-        self._config: dict = config
-        self._poolsize: int = workers
-        self._log_queue = JoinableQueue()
-        self._log_listener = QueueListener(self._log_queue, *handlers)
-        self._workers: list[ProcessWorker] = []
+        context = get_context('spawn')
+        log_queue = context.JoinableQueue(10000)
+        handlers = logging.getLogger().handlers
+        self._log_listener = QueueListener(
+            log_queue, *handlers, respect_handler_level=True
+        )
 
-    def __len__(self):
-        return len(self._workers)
+        self._workers: set[ProcessWorker] = {
+            ProcessWorker(context, config, log_queue, MasterTenantProxy.proxy)
+            for _ in range(workers)
+        }
 
     async def __aenter__(self):
-        self._workers = {
-            ProcessWorker(self._config, self._log_queue, MasterTenantProxy.proxy)
-            for _ in range(self._poolsize)
-        }
-        logger.info('starting %d worker process(es)', self._poolsize)
+        logger.info('starting %d worker process(es)', len(self._workers))
         self._log_listener.start()
         for worker in self._workers:
             worker.start()
@@ -138,7 +147,5 @@ class ProcessPool:
     async def __aexit__(self, *args):
         for worker in self._workers:
             worker.join()
-            worker.close()
-        logger.info('processing queued log messages...')
-        self._log_queue.join()
+        logger.info('processing remaining log messages...')
         self._log_listener.stop()


### PR DESCRIPTION
Changes: 
* Use `spawn` instead of `fork` for worker processes to avoid deadlock bug with logging library and multiprocessing 
* Reduce number of log messages by removing unnecessary (and duplicates) messages
* Revert QueueHandler and use normal handlers for each processes
* Change worker processes name for easier debugging