### PR TITLE
WAZO-3237: use `wazo-websocketd-wait-online` to check when service is ready

### DIFF
--- a/debian/wazo-websocketd.service
+++ b/debian/wazo-websocketd.service
@@ -6,7 +6,8 @@ StartLimitBurst=15
 StartLimitIntervalSec=150
 
 [Service]
-ExecStart=/usr/bin/python3 -u /usr/bin/wazo-websocketd
+ExecStart=/usr/bin/wazo-websocketd
+ExecStartPost=/usr/bin/wazo-websocketd-wait-online
 Restart=on-failure
 RestartSec=5
 

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,10 @@ setup(
     author_email='dev@wazo.community',
     url='http://wazo.community',
     packages=find_packages(),
-    entry_points={'console_scripts': [f'{NAME}=wazo_websocketd.main:main']},
+    entry_points={
+        'console_scripts': [
+            f'{NAME}=wazo_websocketd.main:main',
+            f'{NAME}-wait-online=wazo_websocketd.wait_online:main',
+        ],
+    },
 )

--- a/wazo_websocketd/wait_online.py
+++ b/wazo_websocketd/wait_online.py
@@ -1,0 +1,52 @@
+# Copyright 2023-2023 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from asyncio import TimeoutError
+from wazo_websocketd.config import _DEFAULT_CONFIG
+from websockets.client import connect
+from xivo.chain_map import ChainMap
+from xivo.config_helper import read_config_file_hierarchy
+
+
+HOST = 'localhost'
+RETRY_INTERVAL = 0.5
+TIMEOUT = 60
+
+
+async def wait_opened(host: str, port: int, timeout: float, interval: float):
+    async def retry_connection(host: str, port: int, interval: float) -> bool:
+        while True:
+            try:
+                connection = await connect(f'ws://{host}:{port}')
+            except ConnectionRefusedError:
+                await asyncio.sleep(interval)
+                continue
+            else:
+                await connection.close(code=1000, reason='websocketd is up')
+                return
+
+    await asyncio.wait_for(retry_connection(host, port, interval), timeout)
+
+
+def get_websocketd_port() -> int:
+    file_config = read_config_file_hierarchy(_DEFAULT_CONFIG)
+    config = ChainMap(file_config, _DEFAULT_CONFIG)
+    return config['websocket']['port']
+
+
+def main():
+    port = get_websocketd_port()
+
+    try:
+        asyncio.run(wait_opened(HOST, port, TIMEOUT, RETRY_INTERVAL))
+    except (KeyboardInterrupt, TimeoutError):
+        print(f'could not connect to wazo-websocketd on port {port}', file=sys.stderr)
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds an entry into the systemd service file to wait until TCP server is up and running before changing state to active


__Why:__
* Fixes an issue with services (and acceptance) which currently have no methods to test if websocketd is up and serving requests
* Needed since using `spawn` instead of `fork` for processes as spawn takes longer to start before serving requests

