### PR TITLE
WAZO-3249: Fix permission error

### DIFF
--- a/wazo_websocketd/process.py
+++ b/wazo_websocketd/process.py
@@ -103,7 +103,7 @@ class ProcessPool:
         setup_logging(
             config['log_file'], debug=config['debug'], log_level=config['log_level']
         )
-        silence_loggers(['aioamqp', 'urllib3'], logging.WARNING)
+        silence_loggers(['aioamqp', 'urllib3', 'stevedore.extension'], logging.WARNING)
 
     @staticmethod
     def _run(config: dict):


### PR DESCRIPTION
This PR avoids permission error when `wazo-websocketd` is run from /root.  This error is due to the way processes (writes temporary files) when they are created and the fact that user `wazo-websocketd` doesn't have read/write access to /root directory.   

**Fix**:
Create and change workdir to temporary folder in /tmp, so the processes can be created from anywhere