### PR TITLE
tests: pin requests version to avoid breaking docker lib

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
 aioamqp
 pytest
-requests
+requests<2.30  # avoid to break docker from wazo-test-helpers
 websockets


### PR DESCRIPTION
why: new requests version (2.30) include breaking change that impact
docker library