### PR TITLE
Revert "tests: pin requests version to avoid breaking docker lib"

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
 aioamqp
 pytest
-requests<2.30  # avoid to break docker from wazo-test-helpers
+requests
 websockets


### PR DESCRIPTION
This reverts commit f50a8b026270e4e9fe1f2b40c6c4f40c845dc518.
why: has been integrated into wazo-test-helpers