### PR TITLE
tests: add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*.pyc
+.git
+.tox
+debian
+integration_tests


### PR DESCRIPTION
Why:

* avoid sending large context when building container