### PR TITLE
integration_tests: fix EOFError during failed websocket connection attempts

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -2,4 +2,5 @@ https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
 aioamqp
 pytest
 requests
-websockets
+# Constraint can be removed when issue is fixed: https://github.com/python-websockets/websockets/issues/1548
+websockets<14.0


### PR DESCRIPTION
on connection attempts in WaitUntilValidConnection wait strategy
since this error is raised from websockets.connect on failed handshakes since websockets==14.0
